### PR TITLE
Headerのコンポーネントをapp.jsに移設した。

### DIFF
--- a/indem.html
+++ b/indem.html
@@ -27,18 +27,8 @@
     <title>Vue_test</title>
   </head>
   <body>
-    <div id="header">
-      <page-header>
-        <div
-          slot="header"
-          class="header_tittle my-3 py-3 mx-auto text-white mw-100px"
-        >
-          <h1 class="display-3">Vim道</h1>
-        </div>
-      </page-header>
-    </div>
-
     <div id="app">
+      <page-header></page-header>
       <main-contents></main-contents>
       <primary-button></primary-button>
     </div>
@@ -53,7 +43,6 @@
     <script src="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.js"></script>
 
     <!-- コンポーネントのインポート -->
-    <script src="./src/header.js"></script>
     <script src="./src/app.js"></script>
   </body>
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -23,6 +23,16 @@ const StartPage = {
   `,
 };
 
+const HeaderTemplate = {
+  template: `
+  <div class="p-3 text-center">
+    <div class="header_tittle my-3 py-3 mx-auto text-white mw-100px">
+      <h1 class="display-3">Vim道</h1>        
+    </div>
+  </div>
+`,
+};
+
 const PrimaryButton = {
   template: `
   <div class="button_area m-3 m-md-5">
@@ -33,6 +43,7 @@ const PrimaryButton = {
 const app = createApp({
   components: {
     "main-contents": StartPage,
+    "page-header": HeaderTemplate,
     "primary-button": PrimaryButton,
   },
 });


### PR DESCRIPTION
## 変更の概要

* 独立したJSファイルに記載されていたHeader部分のコンポーネントをapp.jsに移設した。

## なぜこの変更をするのか

* Header部分をVue3の記法で記載した際にid=headerとした際に、メインコンテンツ部分のid=app部分が読み込まれなくなってしまったため修正した。
* コンポーネントの管理をapp.jsに一任したいため、コンポーネント記載部分を移設した。

## やったこと

* [x] HeaderコンポーネントをHeaderTemplateとしてapp.jsに移動。
* [x] createApp内でHeaderTemplateをpage-headerとして定義。
* [X] index.htmlのid=appのdivタグ内でpage-headerコンポーネントを読み込み。 
* [X] index.htmlのheader.jsの読み込み部分を削除。

## 影響範囲

* header.jsを読み込まないように変更しているためhedear.js部分に機能を追加していただいていると動作しない可能性があります。
