### PR TITLE
[feat]ローカル環境で難易度選択画面に遷移できるように/index.htmlのページにボタンを追加した。

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,16 @@
 const { createRouter, createWebHistory, createWebHashHistory } = VueRouter;
 const { createApp } = Vue;
 
+// ローカル環境で/VimQuizのURLに遷移するためのボタン。リリース環境では削除する。
+const DevelopButton = {
+  template: `
+  <div class="button_area m-3 m-md-5">
+    <router-link to="/VimQuiz">
+      <button class="btn btn-danger p-2 text-white">開発環境用ボタン</button>
+    </router-link>
+  </div>`,
+};
+
 const HeaderComponent = {
   template: `
   <div class="p-3 text-center">
@@ -19,7 +29,6 @@ const PrimaryButton = {
     </router-link>
   </div>`,
 };
-
 
 const DifficultyCheckPage = {
   // 最終的にページ全体を1コンポーネントにする。そのコンポーネント内にパーツ化したコンポーネントを読み込む
@@ -57,6 +66,8 @@ const QuizPage = {
 const router = createRouter({
   history: createWebHistory(),
   routes: [
+    { path: "/index.html", component: DevelopButton },
+    // ローカル環境での開発用のルート。リリース環境では削除する。
     { path: "/VimQuiz", component: DifficultyCheckPage },
     { path: "/quiz", component: QuizPage },
   ],


### PR DESCRIPTION
## 変更の概要

* /index.htmlのページに/VimQuizのURLに遷移するためのボタンを追加した。

## なぜこの変更をするのか

* ローカル環境ではルートページのURLが/index.htmlだが、github_pagesのルートページのURLが/VimQuizであり、コンポーネントがうまくレンダリングされなかったため追加した。


## やったこと

* [x] DevelopButtonコンポーネントの追加。
* [x] /index.htmlのルーティングを追加。

## 影響範囲

* 難易度選択画面への遷移用のボタンを作成したのみのため機能的な影響はなし。
* /index.htmlにアクセスされたらボタンが見えてしまうかも。
