### PR TITLE
[refactor]ヘッダーのコンポーネント化の解除

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,11 @@
   <body>
     <div id="app">
       <!-- ヘッダー -->
-      <vim-header></vim-header>
+      <div class="p-3 text-center">
+        <div class="header_tittle my-3 py-3 mx-auto text-white mw-100px">
+          <h1 class="display-3">Vim道</h1>
+        </div>
+      </div>
       ​
       <!-- メインコンテンツ部分 -->
       <div class="text_area w-auto mx-4 mx-md-5 text-white">
@@ -77,7 +81,9 @@
 
         <!-- クイズ画面 -->
         <div v-else key="b">
-          <p class="p-2" id="defaultStatement">説明文にあうコマンドを入力してください</p>
+          <p class="p-2" id="defaultStatement">
+            説明文にあうコマンドを入力してください
+          </p>
           <p class="p-2" id="questionStatement">
             1/{{questionLength}}:{{questions[0].question}}
           </p>

--- a/src/app.js
+++ b/src/app.js
@@ -1,27 +1,17 @@
-const VimHeader = {
-  template:`
-    <div class="p-3 text-center">
-      <div class="header_tittle my-3 py-3 mx-auto text-white mw-100px">
-        <h1 class="display-3">Vim道</h1>
-      </div>
-    </div>
-  `
-}
-
 const app = new Vue({
   el: "#app",
   data: {
     questionMode: true,
     questions: [],
     answer_check: true,
-    questionLength
+    questionLength,
   },
   methods: {
     questionChoose: function () {
       this.questionMode = false;
       clickedStartProblems();
       this.questions = questionArray;
-      this.questionLength = questionLength
+      this.questionLength = questionLength;
     },
     answerCheck: function () {
       this.questionMode = false;
@@ -33,7 +23,4 @@ const app = new Vue({
       this.answer_check = true;
     },
   },
-  components: {
-    'vim-header': VimHeader
-  }
 });


### PR DESCRIPTION
## 変更の理由
ヘッダーをコンポーネント化してapp.jsに配置し、index.htmlではコンポーネントを読み込んでいたがコンポーネント化の恩恵を受けられていなかった。
そのため、他の画面構成要素と同じく、index.htmlに直書きすることとした。

## やったこと
- [x] app.jsからVimHeaderのtemplate部分をindex.htmlに移設。
- [x] app.jsからはVimHeaderを削除。
- [x] VueインスタンスでコンポーネントとしてVimHeaderを読み込んでいた部分を削除。

## その他伝えるべきこと
上記変更をpushするに当たり、過去に自分が作ったrefactoringブランチが残存していたため、refactoring/de-componetizationブランチがpushできないエラーが発生。
refactoringブランチは現在使用していなかったためリモートリポジトリから削除している。